### PR TITLE
Multiple API Docs

### DIFF
--- a/assets/js/api-docs/renderApiDocs.ts
+++ b/assets/js/api-docs/renderApiDocs.ts
@@ -1,0 +1,10 @@
+import SwaggerUI from 'swagger-ui'
+
+const renderApiDocs = (containerId: string, url: string ) => (
+  SwaggerUI({
+    dom_id: `#${containerId}`,
+    url: url
+  })
+)
+
+export { renderApiDocs }

--- a/assets/js/apiDocs.ts
+++ b/assets/js/apiDocs.ts
@@ -1,13 +1,8 @@
-import SwaggerUI from 'swagger-ui'
+import { renderApiDocs } from "./api-docs/renderApiDocs"
 
 document.addEventListener('DOMContentLoaded', function () {
-  const container = document.getElementById('api-docs')
-  if (!container) {
-    return undefined
-  }
-
-  SwaggerUI({
-    dom_id: '#api-docs',
-    url: container.dataset.url
-  })
+  Array.from(document.getElementsByClassName('api-docs'))
+    .forEach((node: HTMLElement) =>
+      renderApiDocs(node.id, node.dataset.url)
+    )
 })

--- a/content/docs/bookstore.md
+++ b/content/docs/bookstore.md
@@ -1,0 +1,5 @@
+---
+title: "BookStore API"
+---
+
+{{< api-docs id="petstore-container" url="https://petstore3.swagger.io/api/v3/openapi.json">}}

--- a/content/docs/combined.md
+++ b/content/docs/combined.md
@@ -1,0 +1,7 @@
+---
+title: "BookStore API & Pet Store"
+---
+
+{{< api-docs "https://raw.githubusercontent.com/Azure/API-Portal/main/api-specs/bookstore.openapi.json">}}
+
+{{< api-docs id="petstore-container" url="https://petstore3.swagger.io/api/v3/openapi.json">}}

--- a/layouts/shortcodes/api-docs.html
+++ b/layouts/shortcodes/api-docs.html
@@ -1,4 +1,8 @@
-<div id="api-docs" data-url="{{.Get 0}}"></div>
+{{ if .IsNamedParams }}
+  <div class="api-docs" id="{{ .Get "id" }}" data-url="{{.Get "url"}}"></div>
+{{ else }}
+  <div class="api-docs" id="api-docs" data-url="{{.Get 0}}"></div>
+{{ end }}
 
 {{ $styleOpts := (dict "includePaths" (slice "node_modules")) }}
 {{ $style := resources.Get "scss/api-docs/main.scss" | resources.ToCSS $styleOpts }}


### PR DESCRIPTION
This PR enhances our API Docs shortcode, making it possible to have multiple specs in one page.
Later we could combine them in different ways, now it just make it possible to the user choose to show more than one.

```
---
title: "BookStore API & Pet Store"
---

{{< api-docs "https://example.com/awesome.openapi.json">}}

{{< api-docs id="petstore-container" url="https://petstore3.swagger.io/api/v3/openapi.json">}}

```

The default would be just the url param, not named. If multiple ones are needed, the params `id` and `url` are needed

<img width="288" alt="Screen Shot 2021-07-09 at 14 24 07" src="https://user-images.githubusercontent.com/4183971/125040030-5ab42f00-e0c1-11eb-9886-73308292335f.png">
