### PR TITLE
[API Docs] JSON object as spec source

### DIFF
--- a/assets/js/api-docs/renderApiDocs.ts
+++ b/assets/js/api-docs/renderApiDocs.ts
@@ -1,10 +1,15 @@
 import SwaggerUI from 'swagger-ui'
 
-const renderApiDocs = (containerId: string, url: string ) => (
-  SwaggerUI({
+const urlExpression = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/gi
+const urlRegex = new RegExp(urlExpression)
+
+const renderApiDocs = (containerId: string, spec: string ) => {
+  const specSource = !!spec.match(urlRegex) ? 'url' : 'spec'
+  const swaggerOptions = {
     dom_id: `#${containerId}`,
-    url: url
-  })
-)
+    [specSource]: JSON.parse(spec)
+  }
+  SwaggerUI(swaggerOptions)
+}
 
 export { renderApiDocs }

--- a/assets/js/apiDocs.ts
+++ b/assets/js/apiDocs.ts
@@ -3,6 +3,6 @@ import { renderApiDocs } from "./api-docs/renderApiDocs"
 document.addEventListener('DOMContentLoaded', function () {
   Array.from(document.getElementsByClassName('api-docs'))
     .forEach((node: HTMLElement) =>
-      renderApiDocs(node.id, node.dataset.url)
+      renderApiDocs(node.id, node.dataset.spec)
     )
 })

--- a/content/docs/bookstore.md
+++ b/content/docs/bookstore.md
@@ -2,4 +2,4 @@
 title: "BookStore API"
 ---
 
-{{< api-docs id="petstore-container" url="https://petstore3.swagger.io/api/v3/openapi.json">}}
+{{< api-docs id="petstore-container" spec="https://petstore3.swagger.io/api/v3/openapi.json">}}

--- a/content/docs/cats.md
+++ b/content/docs/cats.md
@@ -1,0 +1,6 @@
+---
+title: cats API
+---
+
+{{< api-docs `{"openapi":"3.0.0","info":{"title":"toy API"},"version":"1.0.0","servers":[{"url":"http://toys/"}],"paths":{"/toys":{"get":{"operationId":"getToys"}}}}` >}}
+

--- a/content/docs/combined.md
+++ b/content/docs/combined.md
@@ -4,4 +4,4 @@ title: "BookStore API & Pet Store"
 
 {{< api-docs "https://raw.githubusercontent.com/Azure/API-Portal/main/api-specs/bookstore.openapi.json">}}
 
-{{< api-docs id="petstore-container" url="https://petstore3.swagger.io/api/v3/openapi.json">}}
+{{< api-docs id="petstore-container" spec="https://petstore3.swagger.io/api/v3/openapi.json">}}

--- a/layouts/shortcodes/api-docs.html
+++ b/layouts/shortcodes/api-docs.html
@@ -1,5 +1,5 @@
 {{ if .IsNamedParams }}
-  <div class="api-docs" id="{{ .Get "id" }}" data-url="{{.Get "url"}}"></div>
+  <div class="api-docs" id="{{ .Get "id" }}" data-spec="{{.Get "spec"}}"></div>
 {{ else }}
-  <div class="api-docs" id="api-docs" data-url="{{.Get 0}}"></div>
+  <div class="api-docs" id="api-docs" data-spec="{{.Get 0}}"></div>
 {{ end }}


### PR DESCRIPTION
This PR makes the API Docs shortcode more versatile, making it possible to use it with a spec URL and spec object.
It will also enable the CI/CD process to build these kind of documentation pages out of json objects.

Now it could be used both with named parameters and none as the following:

**With spec URL**
Implicit:
`{{< api-docs "https:/example.org/spec.json" >}}`
Named params:
`{{< api-docs id="api-docs" spec="https:/example.org/spec.json" >}}`

**And with the object itself**
Implicit: 
`{{< api-docs "{"openapi":"3.0.0","info":{"title":"toy API"}...}" >}}`
Named params:
`{{< api-docs id="api-docs" spec="{"openapi":"3.0.0","info":{"title":"toy API"}...}" >}}`


