### PR TITLE
[Automation] Generate API pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+#Use bash as shell
+SHELL = /bin/bash
+
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+generate_api_pages: ## Generate api pages.
+	@{ \
+	echo "***************************************************************************"; \
+	echo "Generating API docu pages..."; \
+	cd data/apis; \
+	jq -cr '.[] | .name, .spec' list.json | awk NF | awk 'NR%2 {name=$$0;filename=name".md"; next}{print "---"; print "title: "name" API"; print "---\n"; print "{{< api-docs \`" $$0 "\` >}}"}'; \
+	echo "Done"; \
+	echo "Moving generated pages to 'content/docs'" ;\
+	echo "WARNING: It will overwrite any destination file with the same name" ;\
+	mv -f *.md ../../content/docs ;\
+	echo "Done"; \
+	echo "***************************************************************************"; \
+	}
+
+build: ## Builds the static site
+	@echo "Building site"
+	@hugo --minify

--- a/content/docs/dogs.md
+++ b/content/docs/dogs.md
@@ -1,0 +1,6 @@
+---
+title: dogs API
+---
+
+{{< api-docs `{"openapi":"3.0.0","info":{"title":"toy API"},"version":"1.0.0","servers":[{"url":"http://toys/"}],"paths":{"/toys":{"get":{"operationId":"getToys"}}}}` >}}
+


### PR DESCRIPTION
One of the key features for a fully static Developer Portal is page generation out of dynamic data, and one step to accomplish that is generating out of available local data. Sadly, Hugo doesn't support building pages out of json/yaml/toml files, but there's an issue we can track: https://github.com/gohugoio/hugo/issues/5074. In the meantime, a PoC is to have a task that will generate markdown pages, using our shortcodes and data from a JSON file.

The `make` target `generate_api_pages` will read data from an array of API objects in `data/apis/list.json` and will generate independent API pages that will display an API spec.

The JSON should have the form of:

```json
[{
        "name": "dogs",
        "spec": "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"toy API\"},\"version\":\"1.0.0\",\"servers\":[{\"url\":\"http:\/\/toys\/\"}],\"paths\":{\"\/toys\":{\"get\":{\"operationId\":\"getToys\"}}}}\n"
    }]
```

And the result pages will be placed on the `content/docs` directory with names like `dogs.md` and will look like:

```md
---
title: dogs API
---

{{< api-docs `{"openapi":"3.0.0","info":{"title":"toy API"},"version":"1.0.0","servers":[{"url":"http://toys/"}],"paths":{"/toys":{"get":{"operationId":"getToys"}}}}` >}}

```

That after triggering a Hugo build, will render the following page:

![Screenshot 2021-08-19 at 16 11 14](https://user-images.githubusercontent.com/4183971/130042279-6d0e8a08-ca76-4e3d-a3d6-aa30c37bf926.png)

We could go further and instead of using `jq` + `awk`, using a full Go implementation, or enhancing the current approach to feed the different kind of pages with a template approach
