### PR TITLE
Fix API pages generation

### DIFF
--- a/.github/workflows/gh-api-pages-build-webhook.yml
+++ b/.github/workflows/gh-api-pages-build-webhook.yml
@@ -1,4 +1,4 @@
-name: github pages
+name: Generate API pages
 
 on:
   repository_dispatch:


### PR DESCRIPTION
* The Makefile target fails if any command fails
* It wraps the json list within single quotes
* The push event should look like:

```
{
    "event_type": "api-list",
    "client_payload": {
        "id": "safffeqwdsfwf",
        "type": "api-list",
        "data": "[{\"name\":\"birds\",\"spec\":\"{\\\"openapi\\\":\\\"3.0.0\\\",\\\"info\\\":{\\\"title\\\":\\\"toy API\\\"},\\\"version\\\":\\\"1.0.0\\\",\\\"servers\\\":[{\\\"url\\\":\\\"http://toys/\\\"}],\\\"paths\\\":{\\\"/toys\\\":{\\\"get\\\":{\\\"operationId\\\":\\\"getToys\\\"}}}}\\n\"},{\"name\":\"dogs\",\"spec\":\"{\\\"openapi\\\":\\\"3.0.0\\\",\\\"info\\\":{\\\"title\\\":\\\"toy API\\\"},\\\"version\\\":\\\"1.0.0\\\",\\\"servers\\\":[{\\\"url\\\":\\\"http://toys/\\\"}],\\\"paths\\\":{\\\"/toys\\\":{\\\"get\\\":{\\\"operationId\\\":\\\"getToys\\\"}}}}\\n\"}]"
    }
}
```


The successful deploy out of many tests was https://github.com/3scale-labs/kamrad/actions/runs/1173758246