### PR TITLE
Fix API Docs when passing a URL

### DIFF
--- a/assets/js/api-docs/renderApiDocs.ts
+++ b/assets/js/api-docs/renderApiDocs.ts
@@ -4,10 +4,10 @@ const urlExpression = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{
 const urlRegex = new RegExp(urlExpression)
 
 const renderApiDocs = (containerId: string, spec: string ) => {
-  const specSource = !!spec.match(urlRegex) ? 'url' : 'spec'
+  const isSpecUrl = !!spec.match(urlRegex)
   const swaggerOptions = {
     dom_id: `#${containerId}`,
-    [specSource]: JSON.parse(spec)
+    [isSpecUrl ? 'url' : 'spec']: isSpecUrl ? spec : JSON.parse(spec)
   }
   SwaggerUI(swaggerOptions)
 }


### PR DESCRIPTION
API Docs was broken when passing the spec URL instead of the spec object.
This PoC is growing, soon we must add tests :)
