### PR TITLE
Smart Builds Bis

### DIFF
--- a/.github/workflows/gh-api-pages-build-webhook.yml
+++ b/.github/workflows/gh-api-pages-build-webhook.yml
@@ -12,9 +12,13 @@ jobs:
     outputs:
       needs-build: ${{ steps.check.outputs.flag }}
     steps:
-      - id: check
-        if: secrets.KAMWIEL_API_HASH != github.event.client_payload.hash
-        run: echo "::set-output name=flag::true"
+      - name: Checking Kamwiel hash
+        id: check
+        shell: bash
+        env:
+          STORED_HASH: ${{ secrets.KAMWIEL_API_HASH }}
+          WEBHOOK_HASH: ${{ github.event.client_payload.hash }}
+        run: if [ $STORED_HASH != $WEBHOOK_HASH ]; then echo "::set-output name=flag::true"; fi
 
   deploy_new_apis:
     needs: check-api-hash


### PR DESCRIPTION
This PR continues the work started on https://github.com/3scale-labs/kamrad/pull/29. Sadly some workflows are not able to run in other branches than the default one, so testing them are hard. Even tho it works when checked with `act`, Github has different security features and also different ways of parsing apparently the jobs.

* Github wasn't able to read secrets within steps, so the task was exported to a different job.
* Instead of reading directly the secrets, those were abstracted to env variables
* The GH action provided if statement never worked correctly, so the conditional was extracted to bash


Notes:

This only fixes the checking of the hash... still more fixes to come