### PR TITLE
Update Kamwiel API list state

### DIFF
--- a/.github/workflows/gh-api-pages-build-webhook.yml
+++ b/.github/workflows/gh-api-pages-build-webhook.yml
@@ -87,3 +87,15 @@ jobs:
           value: ${{ github.event.client_payload.hash }}
           repository: '3scale-labs/kamrad'
           token: ${{ secrets.KAMRAD_TOKEN }}
+
+  sync_with_kamwiel:
+    needs: update_api_hash
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Communicate Kamwiel the deploy was successful
+        id: updateKamwielState
+        uses: fjogeleit/http-request-action@master
+        with:
+          method: 'PUT'
+          url: ${{ secrets.KAMWIEL_URL }}/state/${{ github.event.client_payload.hash }}
+          customHeaders: '{"X-API-KEY": "${{ secrets.KAMWIEL_API_KEY }}"}'


### PR DESCRIPTION
As the final step of the generation of API documentation pages, Kamrad needs to let Kamwiel know the build and deploy were successful. Thus, it makes a PUT request to Kamwiel `state` endpoint with the "hash" deployed.
